### PR TITLE
Added .vscode to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ __pycache__/
 ksetpwd/ksetpwd
 ksetpwd/ksetpwd.o
 register-computer/kerberos/bin/
+
+.vscode


### PR DESCRIPTION
This PR adds .vscode/ to .gitignore to ignore files created by Visual Studio Code locally.