### PR TITLE
Fix - Add-Computer fails when running script in WINDOWS_LTSC images

### DIFF
--- a/ad-joining/register-computer/join.ps1
+++ b/ad-joining/register-computer/join.ps1
@@ -78,7 +78,8 @@ do {
             -DomainName $JoinInfo.Domain `
             -Credential $Credentials `
             -OUPath $JoinInfo.OrgUnitPath `
-            -Options UnsecuredJoin,PasswordPass,JoinWithNewName 
+            -Options UnsecuredJoin,PasswordPass,JoinWithNewName `
+            -Force
 
         Write-Host "Computer successfully joined to domain"
         break


### PR DESCRIPTION
Add-Computer attempted to show a prompt when using WINDOWS_LTSC, which caused an exception. Added -Force to not show the prompt