### PR TITLE
Fix krb5.conf

### DIFF
--- a/ad-joining/register-computer/kerberos/password.py
+++ b/ad-joining/register-computer/kerberos/password.py
@@ -44,17 +44,16 @@ class KerberosPasswordClient(object):
         self.__client_password = client_password
 
     def __generate_config_file(self):
-        config = """
-            [libdefaults]
-                default_tkt_enctypes = rc4-hmac
-                default_tgs_enctypes = rc4-hmac
+        config = """[libdefaults]
+default_tkt_enctypes = rc4-hmac
+default_tgs_enctypes = rc4-hmac
 
-            [realms]
-                %s = {
-                    kdc = %s
-                    admin_server = %s
-            }
-            """ % (self.__realm.upper(), self.__kdc, self.__admin_server)
+[realms]
+%s = {
+    kdc = %s
+    admin_server = %s
+}
+""" % (self.__realm.upper(), self.__kdc, self.__admin_server)
 
         handle, name = tempfile.mkstemp(prefix = "krb5.")
         with open(handle, "w", encoding = "utf-8") as f:

--- a/ad-joining/register-computer/kerberos/password.py
+++ b/ad-joining/register-computer/kerberos/password.py
@@ -47,6 +47,8 @@ class KerberosPasswordClient(object):
         config = """[libdefaults]
 default_tkt_enctypes = rc4-hmac
 default_tgs_enctypes = rc4-hmac
+dns_lookup_realm = false
+dns_lookup_kdc = false
 
 [realms]
 %s = {


### PR DESCRIPTION
This PR fixes krb5.conf which contained illegal spaces/line breaks effectively rendering it ineffective. Additionally we prevent SRV lookups for the Kerberos realm and the KDC which may result in krb5 connecting to another domain controller than was initially used to create the computer account/group leading to replication issues and failures.