### PR TITLE
Ignore hydrated cloudbuild.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ ksetpwd/ksetpwd.o
 register-computer/kerberos/bin/
 
 .vscode
+
+ad-joining/cloudbuild.hydrated.yaml


### PR DESCRIPTION
This PR will add `cloudbuild.hydrated.yaml` to ignored files.