### PR TITLE
Add packet capture diagnostics for join operation

### DIFF
--- a/ad-joining/register-computer/join.ps1
+++ b/ad-joining/register-computer/join.ps1
@@ -124,14 +124,7 @@ function Start-JoinDiagnostics
             Write-Information -MessageData "AD Join diagnostics: Enabled"; 
 
             $DiagnosticsCaptureFile = "${env:TEMP}\capture.etl";
-            if((Get-WindowsVersion) -eq 1)
-            {
-                & pktmon start -c --pkt-size 0 -f $DiagnosticsCaptureFile | Out-Null;
-            }
-            else
-            {
-                & netsh trace start capture=yes tracefile=$DiagnosticsCaptureFile | Out-Null;
-            }
+            & netsh trace start capture=yes tracefile=$DiagnosticsCaptureFile | Out-Null;
         }
         else
         {
@@ -164,17 +157,8 @@ function Stop-JoinDiagnostics
             $DiagnosticsCaptureFile = "${env:TEMP}\capture.etl";
             $Timestamp = [DateTime]::Now.ToUniversalTime().ToString("yyyy-MM-dd-HH-mm");
 
-            if((Get-WindowsVersion) -eq 1)
-            {
-                $DiagnosticsOutputFile = "${env:TEMP}\capture.pcapng";
-                & pktmon stop | Out-Null;
-                & pktmon pcapng $DiagnosticsCaptureFile -o $DiagnosticsOutputFile | Out-Null;
-            }
-            else
-            {
-                $DiagnosticsOutputFile = $DiagnosticsCaptureFile;
-                & netsh trace stop | Out-Null;
-            }
+            $DiagnosticsOutputFile = $DiagnosticsCaptureFile;
+            & netsh trace stop | Out-Null;
             
             $Extension = [System.IO.Path]::GetExtension($DiagnosticsOutputFile);
             $DiagnosticsBucketFile = "gs://$DiagnosticsBucket/captures/$($JoinInfo.ComputerName)-$Timestamp$Extension";

--- a/ad-joining/register-computer/join.ps1
+++ b/ad-joining/register-computer/join.ps1
@@ -27,12 +27,60 @@
 #--------------------------------------------------------------------------------------------
 
 $ErrorActionPreference = "Stop"
+$InformationPreference = "Continue";
+
+$metadataUri = "http://metadata.google.internal/computeMetadata/v1/instance";
+$metadataHeaders = @{"Metadata-Flavor" = "Google"};
+
+$enableDiagnostics = $false;
+try
+{
+    $enableDiagnostics = (Invoke-RestMethod -Headers $metadataHeaders `
+        -Uri "$($metadataUri)/attributes/enable-adjoin-diagnostics");
+
+    if($enableDiagnostics)
+    {
+        Write-Information -MessageData "AD Join diagnostics: Enabled"; 
+
+        $diagnosticsBucket = (Invoke-RestMethod -Headers $metadataHeaders `
+            -Uri "$($metadataUri)/attributes/adjoin-diagnostics-bucket");
+
+        if($diagnosticsBucket -eq "")
+        {
+            throw New-Object System.ArgumentException "AD Join diagnostics enabled but bucket not set. Point adjoin-diagnostics-bucket metadata to a GCS bucket the service account has write access to.";
+        }
+
+        $diagnosticCaptureFile = "$env:SystemRoot\temp\capture.etl";
+
+        if([Environment]::OSVersion.Version -ge (New-Object 'Version' 10,0,17763))
+        {
+            # Windows Server 2019 and newer
+            $version = "ws2019";
+
+            & pktmon start -c --pkt-size 0 -f $diagnosticCaptureFile | Out-Null;
+        }
+        else
+        {
+            # Windows Server 2012 R2 or 2016
+            $version = "ws2016"
+
+            & netsh trace start capture=yes tracefile=$diagnosticCaptureFile | Out-Null;
+        }
+    }
+}
+catch
+{
+    # Swallow HTTP 404 thrown if metadata key has not been set
+    # or if bucket has not been set
+    $enableDiagnostics = $false;
+
+    Write-Error -Message "AD Join diagnostics: Failed to start: $($_.Exception.Message)";
+}
 
 # Fetch IdToken that we can use to authenticate the instance with.
 $IdToken = (Invoke-RestMethod `
-    -Headers @{"Metadata-Flavor" = "Google"} `
+    -Headers $metadataHeaders `
     -Uri "http://metadata/computeMetadata/v1/instance/service-accounts/default/identity?audience=%scheme%:%2F%2F%domain%%2F&format=full")
-
 
 # Register computer in Active Directory.
 $JoinInfo = try {
@@ -108,6 +156,31 @@ if ($JoinInfo) {
             else {
                 throw [System.ArgumentException]::new(
                     "Joining computer to domain failed: $($_.Exception.Message)")
+            }
+        }
+        finally
+        {
+            if($enableDiagnostics)
+            {
+                $timestamp = [DateTime]::Now.ToUniversalTime().ToString("yyyy-MM-dd-HH-mm");
+
+                if($version -eq "ws2019")
+                {
+                    $diagnosticOutputFile = "$env:SystemRoot\temp\capture.pcapng";
+                    & pktmon stop | Out-Null;
+                    & pktmon pcapng $diagnosticCaptureFile -o $diagnosticOutputFile | Out-Null;
+                }
+                else
+                {
+                    $diagnosticOutputFile = $diagnosticCaptureFile;
+                    & netsh trace stop | Out-Null;
+                }
+                
+                $extension = [System.IO.Path]::GetExtension($diagnosticOutputFile);
+                $diagnosticBucketFile = "gs://$diagnosticsBucket/captures/$($JoinInfo.ComputerName)-$timestamp$extension";
+                & gsutil -q cp $diagnosticOutputFile $diagnosticBucketFile;
+
+                Write-Information -MessageData "AD Join diagnostics: Packet capture copied to $diagnosticBucketFile"; 
             }
         }
     } while ($True)

--- a/ad-joining/register-computer/join.ps1
+++ b/ad-joining/register-computer/join.ps1
@@ -80,7 +80,7 @@ catch
 # Fetch IdToken that we can use to authenticate the instance with.
 $IdToken = (Invoke-RestMethod `
     -Headers $MetadataHeaders `
-    -Uri "http://metadata/computeMetadata/v1/instance/service-accounts/default/identity?audience=%scheme%:%2F%2F%domain%%2F&format=full")
+    -Uri "$($MetadataUri)/service-accounts/default/identity?audience=%scheme%:%2F%2F%domain%%2F&format=full")
 
 # Register computer in Active Directory.
 $JoinInfo = try {

--- a/ad-joining/register-computer/join.ps1
+++ b/ad-joining/register-computer/join.ps1
@@ -184,7 +184,7 @@ function Stop-JoinDiagnostics
             else
             {
                 # PktMon does not exist in this version of Windows or does not provide trace recording, falling back to netsh trace
-                & netsh trace stop; # | Out-Null;
+                & netsh trace stop | Out-Null;
             }
             
             $Extension = [System.IO.Path]::GetExtension($DiagnosticsOutputFile);

--- a/ad-joining/register-computer/join.ps1
+++ b/ad-joining/register-computer/join.ps1
@@ -51,7 +51,7 @@ try
                 "AD Join diagnostics enabled but bucket not set. Point adjoin-diagnostics-bucket metadata to a GCS bucket the service account has write access to.");
         }
 
-        $DiagnosticsCaptureFile = "$env:SystemRoot\temp\capture.etl";
+        $DiagnosticsCaptureFile = "${env:TEMP}\capture.etl";
 
         if([Environment]::OSVersion.Version -ge (New-Object 'Version' 10,0,17763))
         {
@@ -167,7 +167,7 @@ if ($JoinInfo) {
 
                 if($DiagnosticsOsVersion -eq "ws2019")
                 {
-                    $DiagnosticsOutputFile = "$env:SystemRoot\temp\capture.pcapng";
+                    $DiagnosticsOutputFile = "${env:TEMP}\capture.pcapng";
                     & pktmon stop | Out-Null;
                     & pktmon pcapng $DiagnosticsCaptureFile -o $DiagnosticsOutputFile | Out-Null;
                 }

--- a/ad-joining/register-computer/join.ps1
+++ b/ad-joining/register-computer/join.ps1
@@ -47,7 +47,8 @@ try
 
         if($DiagnosticsBucket -eq "")
         {
-            throw New-Object System.ArgumentException "AD Join diagnostics enabled but bucket not set. Point adjoin-diagnostics-bucket metadata to a GCS bucket the service account has write access to.";
+            throw [System.ArgumentException]::new(
+                "AD Join diagnostics enabled but bucket not set. Point adjoin-diagnostics-bucket metadata to a GCS bucket the service account has write access to.");
         }
 
         $DiagnosticsCaptureFile = "$env:SystemRoot\temp\capture.etl";


### PR DESCRIPTION
This PR adds instrumentation to record a packet capture on the joining VM to analyze the traffic flow during the join operation. This feature is not by default enabled but can be individually enabled by setting `enable-adjoin-diagnostics` and `adjoin-diagnostics-bucket` metadata attributes.