### PR TITLE
Make DC selection site-aware

### DIFF
--- a/ad-joining/register-computer/ad/domain.py
+++ b/ad-joining/register-computer/ad/domain.py
@@ -61,8 +61,17 @@ class ActiveDirectoryConnection(object):
             return str(value)
 
     @staticmethod
-    def locate_domain_controllers(domain_name):
-        records = dns.resolver.query("_ldap._tcp.dc._msdcs.%s" % domain_name, "SRV")
+    def locate_domain_controllers(domain_name, site_name):
+        query = "_ldap._tcp"
+
+        # Use site-awareness if site was provided
+        if not site_name is None and len(site_name) > 0:
+            query += f".{site_name}._sites"
+            logging.info(f"Using site-awareness to select closest DC for site '{site_name}'")
+
+        query += f".dc._msdcs.{domain_name}"
+
+        records = dns.resolver.query(query, "SRV")
         if len(records) == 0:
             raise DomainControllerLookupException("No SRV records found for %s" % domain_name)
 


### PR DESCRIPTION
This PR changes the selection process for the DC against which the computer account creation and password reset operations are executed. On the VM that is to be joined to AD the closest site is determined and then passed to the join function which then will lookup a DC in the closest site. 