### PR TITLE
Fixed AD object cleanup

### DIFF
--- a/ad-joining/register-computer/main.py
+++ b/ad-joining/register-computer/main.py
@@ -88,7 +88,7 @@ def __read_ad_password():
             logging.exception("Could not retrieve secret from Secret Manager: %s" % e)
             raise e
 
-def __connect_to_activedirectory(ad_site):
+def __connect_to_activedirectory(ad_site=None):
     domain = __read_required_setting("AD_DOMAIN")
 
     if "AD_DOMAINCONTROLLER" in os.environ:


### PR DESCRIPTION
This PR makes the ad_site argument in __connect_to_activdirectory optional which broke AD object cleanup. The function already handles an empty argument and ad_site should be optional.