### PR TITLE
Enable LDAPS connections to Active Directory

### DIFF
--- a/ad-joining/README.md
+++ b/ad-joining/README.md
@@ -26,9 +26,12 @@ The `register-computer` app obtains its configuration from the environment and s
 * `AD_DOMAINCONTROLLER` (optional): Name or IP of domain controller to use. If not specified, the app will locate a domain controller via DNS automatically. This variable should only be used for testing.
 * `AD_USERNAME` (required): Username of Active Directory service user. The user must have permission to manage computer objects in the OUs used for automatic domain joining. The value must be provided in `NETBIOS-DOMAIN\SAM-ACCOUNT-NAME` format, UPNs are not supported.
 * `AD_PASSWORD` (optional): Clear-text password of Active Directory service user.  This variable should only be used for testing.
-* `SECRET_PROJECT_ID` (required unless `AD_PASSWORD` is used): Project ID under which the AD credentials have been stored in Secret Manager.
-* `SECRET_NAME` (required unless `AD_PASSWORD` is used): Name of the secret under which the AD credentials have been stored in Secret Manager.
-* `SECRET_VERSION` (required unless `AD_PASSWORD` is used): Version of the secret under which the AD credentials have been stored in Secret Manager. Can be set to `latest`.
+* `SM_PROJECT_ADPASSWORD` (or `SECRET_PROJECT_ID` for backward compatibility) (required unless `AD_PASSWORD` is used): Project ID under which the AD credentials have been stored in Secret Manager.
+* `SM_NAME_ADPASSSWORD` (or `SECRET_NAME` for backward compatibility) (required unless `AD_PASSWORD` is used): Name of the secret under which the AD credentials have been stored in Secret Manager.
+* `SM_VERSION_ADPASSWORD` (or `SECRET_VERSION` for backward compatibility) (required unless `AD_PASSWORD` is used): Version of the secret under which the AD credentials have been stored in Secret Manager. Can be set to `latest`.
+* `SM_PROJECT_CACERT` (optional if a public Certificate Authority is used): Project ID under which the certificate trust chain for the Certification Authority has been stored in Secret Manager.
+* `SM_NAME_CACERT` (optional see `SM_PROJECT_CACERT`): Name of the secret which holds the certificate trust chain for the Certification Authority in Secret Manager.
+* `SM_VERSION_CACERT` (optional see `SM_PROJECT_CACERT`): Version of the secret which holds the certificate trust chain for the Certification Authority in Secret Manager. Can be set to `latest`.
 * `FUNCTION_IDENTITY`: (required) Email address of the app's service account.
 * `LOGGING_LEVEL` (optional): Logging level for log messages. See [Logging Levels](https://docs.python.org/3/library/logging.html#levels) for acceptable values. The default logging level is set to INFO.
 

--- a/ad-joining/README.md
+++ b/ad-joining/README.md
@@ -26,10 +26,9 @@ The `register-computer` app obtains its configuration from the environment and s
 * `AD_DOMAINCONTROLLER` (optional): Name or IP of domain controller to use. If not specified, the app will locate a domain controller via DNS automatically. This variable should only be used for testing.
 * `AD_USERNAME` (required): Username of Active Directory service user. The user must have permission to manage computer objects in the OUs used for automatic domain joining. The value must be provided in `NETBIOS-DOMAIN\SAM-ACCOUNT-NAME` format, UPNs are not supported.
 * `AD_PASSWORD` (optional): Clear-text password of Active Directory service user.  This variable should only be used for testing.
-* `SM_PROJECT_ADPASSWORD` (or `SECRET_PROJECT_ID` for backward compatibility) (required unless `AD_PASSWORD` is used): Project ID under which the AD credentials have been stored in Secret Manager.
+* `SM_PROJECT` (or `SECRET_PROJECT_ID` for backward compatibility): Project ID under which secrets are stored.
 * `SM_NAME_ADPASSSWORD` (or `SECRET_NAME` for backward compatibility) (required unless `AD_PASSWORD` is used): Name of the secret under which the AD credentials have been stored in Secret Manager.
 * `SM_VERSION_ADPASSWORD` (or `SECRET_VERSION` for backward compatibility) (required unless `AD_PASSWORD` is used): Version of the secret under which the AD credentials have been stored in Secret Manager. Defaults to `latest`.
-* `SM_PROJECT_CACERT` (optional if a public Certificate Authority is used): Project ID under which the certificate trust chain for the Certification Authority has been stored in Secret Manager.
 * `SM_NAME_CACERT` (optional see `SM_PROJECT_CACERT`): Name of the secret which holds the certificate trust chain for the Certification Authority in Secret Manager.
 * `SM_VERSION_CACERT` (optional see `SM_PROJECT_CACERT`): Version of the secret which holds the certificate trust chain for the Certification Authority in Secret Manager. Defaults to `latest`.
 * `FUNCTION_IDENTITY`: (required) Email address of the app's service account.

--- a/ad-joining/README.md
+++ b/ad-joining/README.md
@@ -26,14 +26,18 @@ The `register-computer` app obtains its configuration from the environment and s
 * `AD_DOMAINCONTROLLER` (optional): Name or IP of domain controller to use. If not specified, the app will locate a domain controller via DNS automatically. This variable should only be used for testing.
 * `AD_USERNAME` (required): Username of Active Directory service user. The user must have permission to manage computer objects in the OUs used for automatic domain joining. The value must be provided in `NETBIOS-DOMAIN\SAM-ACCOUNT-NAME` format, UPNs are not supported.
 * `AD_PASSWORD` (optional): Clear-text password of Active Directory service user.  This variable should only be used for testing.
-* `USE_LDAPS`: If set to `true` TLS secured LDAP on port 689 will be used when communicating with Active Directory. Defaults to `false`. *Note:* When using LDAPS and a private Certification Authority make sure the public CA certificate is uploaded to Secret Manager and the `SM_NAME_CACERT` and `SM_VERSION_CACERT` options are set accordingly.
 * `SM_PROJECT` (or `SECRET_PROJECT_ID` for backward compatibility): Project ID under which secrets are stored.
 * `SM_NAME_ADPASSWORD` (or `SECRET_NAME` for backward compatibility) (required unless `AD_PASSWORD` is used): Name of the secret under which the AD credentials have been stored in Secret Manager.
 * `SM_VERSION_ADPASSWORD` (or `SECRET_VERSION` for backward compatibility) (required unless `AD_PASSWORD` is used): Version of the secret under which the AD credentials have been stored in Secret Manager. Defaults to `latest`.
-* `SM_NAME_CACERT` (optional see `SM_PROJECT_CACERT`): Name of the secret which holds the certificate trust chain for the Certification Authority in Secret Manager.
-* `SM_VERSION_CACERT` (optional see `SM_PROJECT_CACERT`): Version of the secret which holds the certificate trust chain for the Certification Authority in Secret Manager. Defaults to `latest`.
+
 * `FUNCTION_IDENTITY`: (required) Email address of the app's service account.
 * `LOGGING_LEVEL` (optional): Logging level for log messages. See [Logging Levels](https://docs.python.org/3/library/logging.html#levels) for acceptable values. The default logging level is set to INFO.
+
+If you want to use LDAPS to communicate with Active Directory you will need to pass the following environment variables. [Refer to the Managed Microsoft AD documentation for information on how to enable LDAPS](https://cloud.google.com/managed-microsoft-ad/docs/how-to-use-ldaps).
+
+* `USE_LDAPS`: If set to `true` TLS secured LDAP on port 689 will be used when communicating with Active Directory. Defaults to `false`. __Note:__ When using LDAPS and a private Certification Authority make sure the CA public certificate is uploaded to Secret Manager and the `SM_NAME_CACERT` and `SM_VERSION_CACERT` options are set accordingly.
+* `SM_NAME_CACERT` (optional see `SM_PROJECT_CACERT`): Name of the secret which holds the certificate trust chain for the Certification Authority in Secret Manager.
+* `SM_VERSION_CACERT` (optional see `SM_PROJECT_CACERT`): Version of the secret which holds the certificate trust chain for the Certification Authority in Secret Manager. Defaults to `latest`.
 
 If you run the app locally, you will need to pass the following, additional environment variables to simulate a
 Cloud Run environment:

--- a/ad-joining/README.md
+++ b/ad-joining/README.md
@@ -28,7 +28,7 @@ The `register-computer` app obtains its configuration from the environment and s
 * `AD_PASSWORD` (optional): Clear-text password of Active Directory service user.  This variable should only be used for testing.
 * `USE_LDAPS`: If set to `true` TLS secured LDAP on port 689 will be used when communicating with Active Directory. Defaults to `false`. *Note:* When using LDAPS and a private Certification Authority make sure the public CA certificate is uploaded to Secret Manager and the `SM_NAME_CACERT` and `SM_VERSION_CACERT` options are set accordingly.
 * `SM_PROJECT` (or `SECRET_PROJECT_ID` for backward compatibility): Project ID under which secrets are stored.
-* `SM_NAME_ADPASSSWORD` (or `SECRET_NAME` for backward compatibility) (required unless `AD_PASSWORD` is used): Name of the secret under which the AD credentials have been stored in Secret Manager.
+* `SM_NAME_ADPASSWORD` (or `SECRET_NAME` for backward compatibility) (required unless `AD_PASSWORD` is used): Name of the secret under which the AD credentials have been stored in Secret Manager.
 * `SM_VERSION_ADPASSWORD` (or `SECRET_VERSION` for backward compatibility) (required unless `AD_PASSWORD` is used): Version of the secret under which the AD credentials have been stored in Secret Manager. Defaults to `latest`.
 * `SM_NAME_CACERT` (optional see `SM_PROJECT_CACERT`): Name of the secret which holds the certificate trust chain for the Certification Authority in Secret Manager.
 * `SM_VERSION_CACERT` (optional see `SM_PROJECT_CACERT`): Version of the secret which holds the certificate trust chain for the Certification Authority in Secret Manager. Defaults to `latest`.

--- a/ad-joining/README.md
+++ b/ad-joining/README.md
@@ -28,10 +28,10 @@ The `register-computer` app obtains its configuration from the environment and s
 * `AD_PASSWORD` (optional): Clear-text password of Active Directory service user.  This variable should only be used for testing.
 * `SM_PROJECT_ADPASSWORD` (or `SECRET_PROJECT_ID` for backward compatibility) (required unless `AD_PASSWORD` is used): Project ID under which the AD credentials have been stored in Secret Manager.
 * `SM_NAME_ADPASSSWORD` (or `SECRET_NAME` for backward compatibility) (required unless `AD_PASSWORD` is used): Name of the secret under which the AD credentials have been stored in Secret Manager.
-* `SM_VERSION_ADPASSWORD` (or `SECRET_VERSION` for backward compatibility) (required unless `AD_PASSWORD` is used): Version of the secret under which the AD credentials have been stored in Secret Manager. Can be set to `latest`.
+* `SM_VERSION_ADPASSWORD` (or `SECRET_VERSION` for backward compatibility) (required unless `AD_PASSWORD` is used): Version of the secret under which the AD credentials have been stored in Secret Manager. Defaults to `latest`.
 * `SM_PROJECT_CACERT` (optional if a public Certificate Authority is used): Project ID under which the certificate trust chain for the Certification Authority has been stored in Secret Manager.
 * `SM_NAME_CACERT` (optional see `SM_PROJECT_CACERT`): Name of the secret which holds the certificate trust chain for the Certification Authority in Secret Manager.
-* `SM_VERSION_CACERT` (optional see `SM_PROJECT_CACERT`): Version of the secret which holds the certificate trust chain for the Certification Authority in Secret Manager. Can be set to `latest`.
+* `SM_VERSION_CACERT` (optional see `SM_PROJECT_CACERT`): Version of the secret which holds the certificate trust chain for the Certification Authority in Secret Manager. Defaults to `latest`.
 * `FUNCTION_IDENTITY`: (required) Email address of the app's service account.
 * `LOGGING_LEVEL` (optional): Logging level for log messages. See [Logging Levels](https://docs.python.org/3/library/logging.html#levels) for acceptable values. The default logging level is set to INFO.
 

--- a/ad-joining/README.md
+++ b/ad-joining/README.md
@@ -33,11 +33,13 @@ The `register-computer` app obtains its configuration from the environment and s
 * `FUNCTION_IDENTITY`: (required) Email address of the app's service account.
 * `LOGGING_LEVEL` (optional): Logging level for log messages. See [Logging Levels](https://docs.python.org/3/library/logging.html#levels) for acceptable values. The default logging level is set to INFO.
 
-If you want to use LDAPS to communicate with Active Directory you will need to pass the following environment variables. [Refer to the Managed Microsoft AD documentation for information on how to enable LDAPS](https://cloud.google.com/managed-microsoft-ad/docs/how-to-use-ldaps).
+If you want to use LDAPS to communicate with Active Directory you will need to pass the following environment variables:
 
 * `USE_LDAPS`: If set to `true` TLS secured LDAP on port 689 will be used when communicating with Active Directory. Defaults to `false`. __Note:__ When using LDAPS and a private Certification Authority make sure the CA public certificate is uploaded to Secret Manager and the `SM_NAME_CACERT` and `SM_VERSION_CACERT` options are set accordingly.
 * `SM_NAME_CACERT` (optional see `SM_PROJECT_CACERT`): Name of the secret which holds the certificate trust chain for the Certification Authority in Secret Manager.
 * `SM_VERSION_CACERT` (optional see `SM_PROJECT_CACERT`): Version of the secret which holds the certificate trust chain for the Certification Authority in Secret Manager. Defaults to `latest`.
+
+If you are using Google Microsoft Managed AD, [follow the steps in the documentation to enable LDAPS](https://cloud.google.com/managed-microsoft-ad/docs/how-to-use-ldaps).
 
 If you run the app locally, you will need to pass the following, additional environment variables to simulate a
 Cloud Run environment:

--- a/ad-joining/README.md
+++ b/ad-joining/README.md
@@ -26,6 +26,7 @@ The `register-computer` app obtains its configuration from the environment and s
 * `AD_DOMAINCONTROLLER` (optional): Name or IP of domain controller to use. If not specified, the app will locate a domain controller via DNS automatically. This variable should only be used for testing.
 * `AD_USERNAME` (required): Username of Active Directory service user. The user must have permission to manage computer objects in the OUs used for automatic domain joining. The value must be provided in `NETBIOS-DOMAIN\SAM-ACCOUNT-NAME` format, UPNs are not supported.
 * `AD_PASSWORD` (optional): Clear-text password of Active Directory service user.  This variable should only be used for testing.
+* `USE_LDAPS`: If set to `true` TLS secured LDAP on port 689 will be used when communicating with Active Directory. Defaults to `false`. *Note:* When using LDAPS and a private Certification Authority make sure the public CA certificate is uploaded to Secret Manager and the `SM_NAME_CACERT` and `SM_VERSION_CACERT` options are set accordingly.
 * `SM_PROJECT` (or `SECRET_PROJECT_ID` for backward compatibility): Project ID under which secrets are stored.
 * `SM_NAME_ADPASSSWORD` (or `SECRET_NAME` for backward compatibility) (required unless `AD_PASSWORD` is used): Name of the secret under which the AD credentials have been stored in Secret Manager.
 * `SM_VERSION_ADPASSWORD` (or `SECRET_VERSION` for backward compatibility) (required unless `AD_PASSWORD` is used): Version of the secret under which the AD credentials have been stored in Secret Manager. Defaults to `latest`.

--- a/ad-joining/register-computer/ad/domain.py
+++ b/ad-joining/register-computer/ad/domain.py
@@ -84,7 +84,7 @@ class ActiveDirectoryConnection(object):
         logging.info("Connecting to LDAPS endpoint of '%s' as '%s'" % (domain_controller, user))
         tls_configuration = Tls(ssl.create_default_context(ssl.Purpose.SERVER_AUTH), validate=ssl.CERT_REQUIRED)
 
-        if not certificate_data is None:
+        if certificate_data is not None:
             logging.debug("Using CA certificate data from Secret Manager")
             tls_configuration.ca_certs_data = certificate_data
 

--- a/ad-joining/register-computer/ad/domain.py
+++ b/ad-joining/register-computer/ad/domain.py
@@ -105,9 +105,9 @@ class ActiveDirectoryConnection(object):
             if connection.bind():
                 return ActiveDirectoryConnection(domain_controller, connection, base_dn)        
         except LDAPStrongerAuthRequiredResult:
-            logging.exception("LDAP bind requires a secure connection. Make sure the Certification Authority certificate has been configured")
+            logging.exception("Failed to connect to LDAP endpoint: Active Directory requires LDAPS for NTLM binds")
         except:
-            pass
+            logging.warn("Failed to connect to LDAP endpoint: %s" % e)
 
         # LDAP connection could not be established, raise exception
         raise LdapException("Connecting to LDAP(S) endpoints of '%s' as '%s' failed" % (domain_controller, user))

--- a/ad-joining/register-computer/ad/domain.py
+++ b/ad-joining/register-computer/ad/domain.py
@@ -23,7 +23,7 @@ import ssl
 import ldap3
 import ldap3.utils.conv
 from ldap3 import Tls
-from ldap3.core.exceptions import LDAPException
+from ldap3.core.exceptions import LDAPException, LDAPStrongerAuthRequiredResult
 import ldap3.core.exceptions
 import logging
 import dns.resolver
@@ -104,10 +104,13 @@ class ActiveDirectoryConnection(object):
         try:
             if connection.bind():
                 return ActiveDirectoryConnection(domain_controller, connection, base_dn)        
-        except LDAPException:
-            logging.warn("Failed to connect to LDAPS endpoint: %s" % e)
-        
-        raise LdapException("Connecting to LDAP(S) endpoints of '%s' as '%s' failed, check credentials" % (domain_controller, user))
+        except LDAPStrongerAuthRequiredResult:
+            logging.exception("LDAP bind requires a secure connection. Make sure the Certification Authority certificate has been configured")
+        except:
+            pass
+
+        # LDAP connection could not be established, raise exception
+        raise LdapException("Connecting to LDAP(S) endpoints of '%s' as '%s' failed" % (domain_controller, user))
 
     def get_domain_controller(self):
         return self.__domain_controller

--- a/ad-joining/register-computer/ad/domain.py
+++ b/ad-joining/register-computer/ad/domain.py
@@ -85,7 +85,7 @@ class ActiveDirectoryConnection(object):
         tls_configuration = Tls(ssl.create_default_context(ssl.Purpose.SERVER_AUTH), validate=ssl.CERT_REQUIRED)
 
         if not certificate_data is None:
-            logging.info("Using CA certificate data from Secret Manager")
+            logging.debug("Using CA certificate data from Secret Manager")
             tls_configuration.ca_certs_data = certificate_data
 
         server = ldap3.Server(domain_controller, port=636, connect_timeout=5, use_ssl=True, tls=tls_configuration)

--- a/ad-joining/register-computer/ad/domain.py
+++ b/ad-joining/register-computer/ad/domain.py
@@ -80,37 +80,38 @@ class ActiveDirectoryConnection(object):
         return [str(record.target)[:-1] if str(record.target).endswith(".") else str(record.target) for record in records_sorted]
 
     @staticmethod
-    def connect(domain_controller, base_dn, user, password, certificate_data=None):
-        logging.info("Connecting to LDAPS endpoint of '%s' as '%s'" % (domain_controller, user))
-        tls_configuration = Tls(ssl.create_default_context(ssl.Purpose.SERVER_AUTH), validate=ssl.CERT_REQUIRED)
+    def connect(domain_controller, base_dn, user, password, use_ldaps=False, certificate_data=None):
+        if use_ldaps:
+            logging.info("Connecting to LDAPS endpoint of '%s' as '%s'" % (domain_controller, user))
+            tls_configuration = Tls(ssl.create_default_context(ssl.Purpose.SERVER_AUTH), validate=ssl.CERT_REQUIRED)
 
-        if certificate_data is not None:
-            logging.debug("Using CA certificate data from Secret Manager")
-            tls_configuration.ca_certs_data = certificate_data
+            if certificate_data is not None:
+                logging.debug("Using CA certificate data from Secret Manager")
+                tls_configuration.ca_certs_data = certificate_data
 
-        server = ldap3.Server(domain_controller, port=636, connect_timeout=5, use_ssl=True, tls=tls_configuration)
-        connection = ldap3.Connection(server, user=user, password=password, authentication=ldap3.NTLM, raise_exceptions=True)
+            server = ldap3.Server(domain_controller, port=636, connect_timeout=5, use_ssl=True, tls=tls_configuration)
+            connection = ldap3.Connection(server, user=user, password=password, authentication=ldap3.NTLM, raise_exceptions=True)
 
-        try:
-            if connection.bind():
-                return ActiveDirectoryConnection(domain_controller, connection, base_dn)
-        except LDAPException as e:
-            logging.warn("Failed to connect to LDAPS endpoint: %s" % e)
-            
-        logging.info("Falling back to LDAP endpoint of '%s' as '%s'" % (domain_controller, user))
-        server = ldap3.Server(domain_controller, port=389, connect_timeout=5, use_ssl=False)
-        connection = ldap3.Connection(server, user=user, password=password, authentication=ldap3.NTLM, raise_exceptions=True)
+            try:
+                if connection.bind():
+                    return ActiveDirectoryConnection(domain_controller, connection, base_dn)
+            except LDAPException as e:
+                logging.warn("Failed to connect to LDAPS endpoint: %s" % e)
+        else:
+            logging.info("Connecting to LDAP endpoint of '%s' as '%s'" % (domain_controller, user))
+            server = ldap3.Server(domain_controller, port=389, connect_timeout=5, use_ssl=False)
+            connection = ldap3.Connection(server, user=user, password=password, authentication=ldap3.NTLM, raise_exceptions=True)
 
-        try:
-            if connection.bind():
-                return ActiveDirectoryConnection(domain_controller, connection, base_dn)        
-        except LDAPStrongerAuthRequiredResult:
-            logging.exception("Failed to connect to LDAP endpoint: Active Directory requires LDAPS for NTLM binds")
-        except:
-            logging.warn("Failed to connect to LDAP endpoint: %s" % e)
+            try:
+                if connection.bind():
+                    return ActiveDirectoryConnection(domain_controller, connection, base_dn)        
+            except LDAPStrongerAuthRequiredResult:
+                logging.exception("Failed to connect to LDAP endpoint: Active Directory requires LDAPS for NTLM binds")
+            except:
+                logging.warn("Failed to connect to LDAP endpoint: %s" % e)
 
         # LDAP connection could not be established, raise exception
-        raise LdapException("Connecting to LDAP(S) endpoints of '%s' as '%s' failed" % (domain_controller, user))
+        raise LdapException("Connecting to LDAP endpoint of '%s' as '%s' failed" % (domain_controller, user))
 
     def get_domain_controller(self):
         return self.__domain_controller

--- a/ad-joining/register-computer/main.py
+++ b/ad-joining/register-computer/main.py
@@ -106,6 +106,9 @@ def __read_certificate_data():
     return None
 
 def __read_secret_manager(project_id, name, version):
+    if not version is None:
+        version = "latest"
+
     try:
         client = secretmanager.SecretManagerServiceClient()
 

--- a/ad-joining/register-computer/main.py
+++ b/ad-joining/register-computer/main.py
@@ -153,7 +153,9 @@ def __connect_to_activedirectory(ad_site=None):
             domain, ad_site)
 
     # Determine if LDAPS should be used for Active Directory connection
+    # Environmental variable stores strings convert to bool
     use_ldaps = __read_setting("USE_LDAPS")
+    use_ldaps = False if use_ldaps is None else use_ldaps.lower() == "true"
 
     certificate_data = None
     if use_ldaps:

--- a/ad-joining/register-computer/main.py
+++ b/ad-joining/register-computer/main.py
@@ -86,10 +86,10 @@ def __read_setting_secret_manager_project(required=False):
     return project_id;
 
 def __read_secret_manager(project_id, name, version):
-    if project_id is not None:
+    if project_id is None:
         raise ConfigurationException("Secret Manager project ID not specified")
 
-    if version is not None:
+    if version is None:
         version = "latest"
 
     try:

--- a/ad-joining/register-computer/main.py
+++ b/ad-joining/register-computer/main.py
@@ -99,7 +99,7 @@ def __read_certificate_data():
     secret_name = __read_setting("SM_NAME_CACERT")
     secret_version = __read_setting("SM_VERSION_CACERT")
 
-    if not secret_project_id is None and not secret_name is None and not secret_version is None:
+    if not (secret_project_id is None or secret_name is None or secret_version is None):
         logging.info("Reading certificate data from Secret Manager")
         return __read_secret_manager(secret_project_id, secret_name, secret_version)
     

--- a/ad-joining/register-computer/main.py
+++ b/ad-joining/register-computer/main.py
@@ -152,8 +152,13 @@ def __connect_to_activedirectory(ad_site=None):
         domain_controllers = ad.domain.ActiveDirectoryConnection.locate_domain_controllers(
             domain, ad_site)
 
-    # Retrieve certificate data from Secret Manager
-    certificate_data = __read_certificate_data()
+    # Determine if LDAPS should be used for Active Directory connection
+    use_ldaps = __read_setting("USE_LDAPS")
+
+    certificate_data = None
+    if use_ldaps:
+        # Retrieve certificate data from Secret Manager
+        certificate_data = __read_certificate_data()
 
     # If we used SRV records to look up domain controllers, then it is possible that
     # the highest-priority one is offline. So loop over the records to fine one
@@ -165,6 +170,7 @@ def __connect_to_activedirectory(ad_site=None):
                     ",".join(["DC=" + dc for dc in domain.split(".")]),
                     __read_required_setting("AD_USERNAME"),
                     __read_ad_password(),
+                    use_ldaps,
                     certificate_data)
         except Exception as e:
             logging.exception("Failed to connect to DC '%s': %s" % (dc, e))

--- a/ad-joining/register-computer/main.py
+++ b/ad-joining/register-computer/main.py
@@ -146,7 +146,7 @@ def __connect_to_activedirectory(ad_site):
                     __read_ad_password(),
                     certificate_data)
         except Exception as e:
-            logging.exception("Failed to connect to DC '%s'" % dc)
+            logging.exception("Failed to connect to DC '%s': %s" % (dc, e))
 
     raise ad.domain.LdapException("No more DCs left to try")
 

--- a/ad-joining/register-computer/main.py
+++ b/ad-joining/register-computer/main.py
@@ -84,7 +84,7 @@ def __read_ad_password():
             return __read_secret_manager(
                 __read_required_setting("SM_PROJECT_ADPASSWORD"), 
                 __read_required_setting("SM_NAME_ADPASSWORD"), 
-                __read_required_setting("SM_VERSION_ADPASSWORD"))
+                __read_setting("SM_VERSION_ADPASSWORD"))
         except ConfigurationException:
             logging.warn("Could not read SM_*_ADPASSWORD settings, falling back to deprecated settings SECRET_PROJECT_ID, SECRET_NAME and SECRET_VERSION")
 
@@ -92,7 +92,7 @@ def __read_ad_password():
         return __read_secret_manager(
             __read_required_setting("SECRET_PROJECT_ID"), 
             __read_required_setting("SECRET_NAME"), 
-            __read_required_setting("SECRET_VERSION"))
+            __read_setting("SECRET_VERSION"))
 
 def __read_certificate_data():
     secret_project_id = __read_setting("SM_PROJECT_CACERT")
@@ -106,7 +106,7 @@ def __read_certificate_data():
     return None
 
 def __read_secret_manager(project_id, name, version):
-    if not version is None:
+    if version is not None:
         version = "latest"
 
     try:

--- a/ad-joining/register-computer/main.py
+++ b/ad-joining/register-computer/main.py
@@ -90,6 +90,7 @@ def __read_secret_manager(project_id, name, version):
         raise ConfigurationException("Secret Manager project ID not specified")
 
     if version is None:
+        logging.debug("Secret version for '%s' not specified, using 'latest'" % name)
         version = "latest"
 
     try:


### PR DESCRIPTION
This PR adds the capability to use LDAPS to Active Directory. LDAPS will be on by default but fallback to LDAP is automatic if a secure connection can't be established. Customers using private non-public Certification Authorities can upload their trust chain to secret manager to allow for server certificate verification.

This PR closes #41. 