### PR TITLE
Retrieve domain name from join service

### DIFF
--- a/ad-joining/register-computer/join.ps1
+++ b/ad-joining/register-computer/join.ps1
@@ -234,7 +234,13 @@ $IdToken = (Invoke-RestMethod `
 $AdSite = "";
 try
 {
-    $Result = & nltest /dsgetdc:%ad_domain% /DS_6 /TRY_NEXT_CLOSEST_SITE;
+    # Retrieve domain name from adjoin service
+    $Domain = Invoke-RestMethod `
+        -Headers @{"Authorization" = "Bearer $IdToken"} `
+        -Method GET `
+        -Uri "%scheme%://%domain%/domain";
+    
+    $Result = & nltest /dsgetdc:$Domain /DS_6 /TRY_NEXT_CLOSEST_SITE;
     $PatternMatches = ($Result | Select-String -Pattern "^Our Site Name: (.+)$").Matches;
     
     if($Null -ne $PatternMatches)

--- a/ad-joining/register-computer/main.py
+++ b/ad-joining/register-computer/main.py
@@ -751,13 +751,11 @@ def register_computer(request):
         Cloud Functions entry point.
     """
     
-    ad_domain = __read_required_setting("AD_DOMAIN")
-
     if request.path == "/hc" and request.method == "GET":
         # Health Check
         return flask.Response(status=HTTP_OK)
     elif request.path == "/domain" and request.method == "GET":
-        return __serve_domain_name(request, ad_domain)
+        return __serve_domain_name(request, __read_required_setting("AD_DOMAIN"))
     elif request.path == "/cleanup" and request.method == "POST":
         return __cleanup_computers(request)
     elif request.path == "/" and request.method == "GET":

--- a/ad-joining/register-computer/main.py
+++ b/ad-joining/register-computer/main.py
@@ -304,6 +304,24 @@ def __get_custom_ou_for_computer(ad_connection, gce_instance, instance_name, pro
     
     return computer_ou
 
+def __authenticate_request(request):
+    # Only accept requests with an Authorization header.
+    headerName = "Authorization"
+    if not headerName in request.headers:
+        logging.exception("Authentication missing")
+        flask.abort(HTTP_AUTHENTICATION_REQUIRED, description="CALLER_AUTHENTICATION_MISSING")
+
+    # Authenticate the request.
+    # Expect the host as audience so that multiple deployments of this
+    # services properly reject tokens issued for other deployments.
+    try:
+        return gcp.auth.AuthenticationInfo.from_authorization_header(
+            request.headers[headerName],
+            "%s://%s/" % (__get_request_scheme(request), request.host))
+    except gcp.auth.AuthorizationException as e:
+        logging.exception("Authentication failed")
+        flask.abort(HTTP_ACCESS_DENIED, description="CALLER_AUTHENTICATION_FAILED")
+
 #------------------------------------------------------------------------------
 # HTTP endpoints.
 #------------------------------------------------------------------------------
@@ -317,7 +335,7 @@ HTTP_CONFLICT = 409
 HTTP_INTERNAL_SERVER_ERROR = 500
 HTTP_BAD_GATEWAY = 502
 
-def __serve_join_script(request, ad_domain):
+def __serve_join_script(request):
     """
     Return the PowerShell script to be run on the joining computer. The script
     does not contain any information about the AD domain or infrastructure so that
@@ -327,31 +345,22 @@ def __serve_join_script(request, ad_domain):
         join_script = file.read()
         join_script = join_script.replace("%domain%", request.host)
         join_script = join_script.replace("%scheme%", __get_request_scheme(request))
-        join_script = join_script.replace("%ad_domain%", ad_domain)
 
         return flask.Response(join_script, mimetype='text/plain')
+
+def __serve_domain_name(request, ad_domain):
+    # Authenticate HTTP request
+    __authenticate_request(request)
+
+    return flask.Response(ad_domain, mimetype='text/plain')
 
 def __register_computer(request):
     """
         Create a computer account for the joining computer.
-    """    
+    """
    
-    # Only accept requests with an Authorization header.
-    headerName = "Authorization"
-    if not headerName in request.headers:
-        logging.exception("Authentication missing")
-        return flask.abort(HTTP_AUTHENTICATION_REQUIRED, description="CALLER_AUTHENTICATION_MISSING")
-
-    # Authenticate the request.
-    # Expect the host as audience so that multiple deployments of this
-    # services properly reject tokens issued for other deployments.
-    try:
-        auth_info = gcp.auth.AuthenticationInfo.from_authorization_header(
-            request.headers[headerName],
-            "%s://%s/" % (__get_request_scheme(request), request.host))
-    except gcp.auth.AuthorizationException as e:
-        logging.exception("Authentication failed")
-        return flask.abort(HTTP_ACCESS_DENIED, description="CALLER_AUTHENTICATION_FAILED")
+    # Authenticate HTTP request
+    auth_info = __authenticate_request(request)
 
     # Connect to Active Directory so that we can authorize the request.
     try:
@@ -613,23 +622,8 @@ def __cleanup_computers(request):
         Clean up stale computer accounts.
     """
 
-    # Only accept requests with an Authorization header.
-    headerName = "Authorization"
-    if not headerName in request.headers:
-        logging.exception("Authentication missing")
-        return flask.abort(HTTP_AUTHENTICATION_REQUIRED, description="CALLER_AUTHENTICATION_MISSING")
-
-    # Authenticate the request.
-    # Expect the host as audience so that multiple deployments of this
-    # services properly reject tokens issued for other deployments.
-    try:
-        auth_info = gcp.auth.AuthenticationInfo.from_authorization_header(
-            request.headers[headerName],
-            "%s://%s/" % (__get_request_scheme(request), request.host),
-            False)
-    except gcp.auth.AuthorizationException as e:
-        logging.exception("Authentication failed")
-        return flask.abort(HTTP_ACCESS_DENIED, description="CALLER_AUTHENTICATION_FAILED")
+    # Authenticate HTTP request
+    auth_info = __authenticate_request(request)
 
     # Authorize the request. The request must be using the same service
     # account as the cloud function in order to be considered legitimate.
@@ -756,23 +750,29 @@ def register_computer(request):
     """
         Cloud Functions entry point.
     """
+    
+    ad_domain = __read_required_setting("AD_DOMAIN")
+
     if request.path == "/hc" and request.method == "GET":
         # Health Check
         return flask.Response(status=HTTP_OK)
+    elif request.path == "/domain" and request.method == "GET":
+        return __serve_domain_name(request, ad_domain)
     elif request.path == "/cleanup" and request.method == "POST":
         return __cleanup_computers(request)
     elif request.path == "/" and request.method == "GET":
-        return __serve_join_script(request, __read_required_setting("AD_DOMAIN"))
+        return __serve_join_script(request)
     elif request.path == "/" and request.method == "POST":
         return __register_computer(request)
     else:
-        return flask.abort(HTTP_BAD_METHOD)
+        flask.abort(HTTP_BAD_METHOD)
 
 app = Flask(__name__)
 app.debug = False
 
 @app.route("/", methods=['GET', 'POST'])
 @app.route("/cleanup", methods=['GET', 'POST'])
+@app.route("/domain", methods=['GET'])
 @app.route("/hc", methods=['GET'])
 
 def index():
@@ -786,4 +786,3 @@ for code in werkzeug.exceptions.default_exceptions:
 
 if __name__ == "__main__":
     app.run()
-


### PR DESCRIPTION
This PR changes the behavior of the join script retrieved by the client in order to perform the domain join. The domain name, required for AD site-awareness will now be retrieved from the join service protected by authentication.