### PR TITLE
Remove fixed usage of RC4 encryption for TKT and TGS

### DIFF
--- a/ad-joining/register-computer/kerberos/password.py
+++ b/ad-joining/register-computer/kerberos/password.py
@@ -45,8 +45,6 @@ class KerberosPasswordClient(object):
 
     def __generate_config_file(self):
         config = """[libdefaults]
-default_tkt_enctypes = rc4-hmac
-default_tgs_enctypes = rc4-hmac
 dns_lookup_realm = false
 dns_lookup_kdc = false
 

--- a/ad-joining/register-computer/main.py
+++ b/ad-joining/register-computer/main.py
@@ -47,7 +47,7 @@ MAX_NETBIOS_COMPUTER_NAME_LENGTH = 15
 PASSWORD_RESET_RETRIES = 10
 
 PROGRAM_NAME = "ad-joining"
-PROGRAM_VERSION = "2.0.0"
+PROGRAM_VERSION = "2.0.1"
 
 #------------------------------------------------------------------------------
 # Utility functions.


### PR DESCRIPTION
This PR will remove the fixed usage of RC4 encryption type for TKT and TGS and allow [the defaults](https://web.mit.edu/kerberos/krb5-1.18/doc/admin/conf_files/krb5_conf.html#libdefaults) to take hold. 