### PR TITLE
Properly handle upstream errors

### DIFF
--- a/ad-joining/register-computer/join.ps1
+++ b/ad-joining/register-computer/join.ps1
@@ -272,10 +272,20 @@ $JoinInfo = try {
     $reader = New-Object System.IO.StreamReader($_.Exception.Response.GetResponseStream())
     $reader.BaseStream.Position = 0
     $reader.DiscardBufferedData()
-    $errorObject = $reader.ReadToEnd() | ConvertFrom-Json
+    $errorData = $reader.ReadToEnd();
 
-    Write-Host $_.Exception.Message 
-    Write-Host "Error is:" $errorObject.error
+    # Load Balancer may return something different than JSON
+    try
+    {
+        $errorObject = $errorData | ConvertFrom-Json;
+        Write-Host $_.Exception.Message 
+        Write-Host "Error is:" $errorObject.error
+    }
+    catch
+    {
+        Write-Error $errorData;
+    }
+
     Write-Host "Failed to register computer account."
 }
 

--- a/ad-joining/register-computer/main.py
+++ b/ad-joining/register-computer/main.py
@@ -47,7 +47,7 @@ MAX_NETBIOS_COMPUTER_NAME_LENGTH = 15
 PASSWORD_RESET_RETRIES = 10
 
 PROGRAM_NAME = "ad-joining"
-PROGRAM_VERSION = "2.0.1"
+PROGRAM_VERSION = "2.0.2"
 
 #------------------------------------------------------------------------------
 # Utility functions.


### PR DESCRIPTION
In case the service (or load balancer/reverse proxy) in front of the service does not return JSON handle the error accordingly and provide proper output to the console.