### PR TITLE
Make server workers configurable

### DIFF
--- a/ad-joining/Dockerfile
+++ b/ad-joining/Dockerfile
@@ -24,6 +24,9 @@ ADD /ksetpwd /ksetpwd
 RUN cd /ksetpwd && make ksetpwd
 
 FROM python:3.7-slim
+
+ENV SERVER_WORKERS=3
+
 ADD /register-computer /register-computer
 RUN groupadd -r runner && \
     useradd -rm -g runner runner && \
@@ -40,4 +43,4 @@ RUN chown -R runner /register-computer && \
 USER runner
 WORKDIR /register-computer
 
-CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 --timeout 0 main:app
+CMD exec gunicorn --bind :$PORT --workers $SERVER_WORKERS --timeout 0 main:app

--- a/ad-joining/register-computer/main.py
+++ b/ad-joining/register-computer/main.py
@@ -47,7 +47,7 @@ MAX_NETBIOS_COMPUTER_NAME_LENGTH = 15
 PASSWORD_RESET_RETRIES = 10
 
 PROGRAM_NAME = "ad-joining"
-PROGRAM_VERSION = "2.0.1"
+PROGRAM_VERSION = "2.0.3"
 
 #------------------------------------------------------------------------------
 # Utility functions.


### PR DESCRIPTION
This PR will allow to configure the number of workers that are spawned when the container is started. The rule of thumb is (vCPU*2)+1.