### PR TITLE
Upgrade to Python 3.10

### DIFF
--- a/ad-joining/Dockerfile
+++ b/ad-joining/Dockerfile
@@ -23,7 +23,7 @@ FROM gcc:latest as build-cc
 ADD /ksetpwd /ksetpwd
 RUN cd /ksetpwd && make ksetpwd
 
-FROM python:3.7-slim
+FROM python:3.10-slim
 
 ENV SERVER_WORKERS=3
 

--- a/ad-joining/register-computer/main.py
+++ b/ad-joining/register-computer/main.py
@@ -47,7 +47,7 @@ MAX_NETBIOS_COMPUTER_NAME_LENGTH = 15
 PASSWORD_RESET_RETRIES = 10
 
 PROGRAM_NAME = "ad-joining"
-PROGRAM_VERSION = "2.0.4"
+PROGRAM_VERSION = "2.0.6"
 
 #------------------------------------------------------------------------------
 # Utility functions.


### PR DESCRIPTION
Python 3.7 will be [end of life in nine months](https://endoflife.date/python). This PR upgrades to Python 3.10 using the slim container base image.