### PR TITLE
Add pycryptodome dependency

### DIFF
--- a/ad-joining/register-computer/main.py
+++ b/ad-joining/register-computer/main.py
@@ -47,7 +47,7 @@ MAX_NETBIOS_COMPUTER_NAME_LENGTH = 15
 PASSWORD_RESET_RETRIES = 10
 
 PROGRAM_NAME = "ad-joining"
-PROGRAM_VERSION = "2.0.4"
+PROGRAM_VERSION = "2.0.7"
 
 #------------------------------------------------------------------------------
 # Utility functions.

--- a/ad-joining/register-computer/requirements.txt
+++ b/ad-joining/register-computer/requirements.txt
@@ -29,3 +29,4 @@ google-cloud-secret-manager>=2.0.0
 oauth2client>=4.1.3
 dnspython>=1.16
 gunicorn>=20.0.4
+pycryptodome==3.15.0


### PR DESCRIPTION
When running the service in a local dev environment or using another base image than specified in Dockerfile, a Python dependency to support cryptographic operations is missing and MD4 hashing will fail. By adding `pycryptodome` this is fixed.  