### PR TITLE
Update requirements.txt

### DIFF
--- a/ad-joining/register-computer/requirements.txt
+++ b/ad-joining/register-computer/requirements.txt
@@ -29,3 +29,4 @@ google-cloud-secret-manager==2.12.4
 oauth2client==4.1.3
 dnspython==2.2.1
 gunicorn==20.1.0
+pycryptodome==3.18.0


### PR DESCRIPTION
Receiving "unsupported hash type MD4" error. Per this GitHub issue, https://github.com/cannatag/ldap3/issues/1038, adding pycryptodome will unblock that error