### PR TITLE
Set custom user agent in Compute Engine API requests

### DIFF
--- a/ad-joining/README.md
+++ b/ad-joining/README.md
@@ -90,9 +90,9 @@ You can run `main.py` locally for testing and debugging purposes:
 
 ### Invoking the app
 
-To invoke the app, you need a valid ID Token. To obtain one, launch VM instance and run the following command:
+To invoke the app, you need a valid ID Token. To obtain one, launch a VM instance and run the following command:
 
-`curl -H "Metadata-Flavor: Google" 'http://metadata/computeMetadata/v1/instance/service-accounts/default/identity?audience=https://127.0.0.1:5000/&format=full'`
+`curl -H "Metadata-Flavor: Google" "http://metadata/computeMetadata/v1/instance/service-accounts/default/identity?audience=https://127.0.0.1:5000/&format=full"`
 
 Given an ID Token, you can send a request to the app:
 

--- a/ad-joining/register-computer/gcp/project.py
+++ b/ad-joining/register-computer/gcp/project.py
@@ -19,13 +19,23 @@
 # under the License.
 #
 
+import google.auth
+import google_auth_httplib2
 import googleapiclient.discovery
 from googleapiclient.errors import HttpError
+import googleapiclient.http
+
+USER_AGENT = "cloud-solutions/gce-automated-ad-join-v1"
 
 class Project(object):
     def __init__(self, project_id):
+        credentials, _ = google.auth.default()
+        
+        auth_http = google_auth_httplib2.AuthorizedHttp(credentials)
+        googleapiclient .http.set_user_agent(auth_http, USER_AGENT)
+
         self.__project_id = project_id
-        self.__gce_client = googleapiclient.discovery.build('compute', 'v1')
+        self.__gce_client = googleapiclient.discovery.build('compute', 'v1', http=auth_http)
 
     def get_zones(self):
         page_token = None

--- a/ad-joining/register-computer/main.py
+++ b/ad-joining/register-computer/main.py
@@ -389,11 +389,11 @@ def __register_computer(request):
     # reduces the risk of us not being able to scavenge later because of lacking
     # permissions.
     try:
-        gce_client = googleapiclient.discovery.build('compute', 'v1')
-        gce_instance = gce_client.instances().get(
-            project=auth_info.get_project_id(),
-            zone=auth_info.get_zone(),
-            instance=auth_info.get_instance_name()).execute()
+        gce_instance = gcp.project.Project(auth_info.get_project_id()).get_instance(
+            auth_info.get_instance_name(), 
+            auth_info.get_zone())
+        if gce_instance is None:
+            raise Exception("Instance does not exist")
 
         # Read the hostname, it might be different from the instance name.
         if "hostname" in gce_instance:


### PR DESCRIPTION
- Initialize client so that it sends a `User-Agent` header in all requests
- Use same client across all files