### PR TITLE
Clean up DNS records of stale computer accounts

### DIFF
--- a/ad-joining/cloudbuild.yaml
+++ b/ad-joining/cloudbuild.yaml
@@ -65,9 +65,9 @@ steps:
   - --service-account=$_SERVICE_ACCOUNT_EMAIL
   - --set-env-vars=AD_DOMAIN=$_AD_DOMAIN 
   - --set-env-vars=AD_USERNAME=$_AD_NETBIOS_DOMAIN\register-computer 
-  - --set-env-vars=SECRET_PROJECT_ID=$PROJECT_ID 
-  - --set-env-vars=SECRET_NAME=$_SECRET_NAME 
-  - --set-env-vars=SECRET_VERSION=$_SECRET_VERSION 
+  - --set-env-vars=SM_PROJECT=$PROJECT_ID 
+  - --set-env-vars=SM_NAME_ADPASSWORD=$_SECRET_NAME 
+  - --set-env-vars=SM_VERSION_ADPASSWORD=$_SECRET_VERSION 
   - --set-env-vars=FUNCTION_IDENTITY=$_SERVICE_ACCOUNT_EMAIL
   - --set-env-vars=^:^PROJECTS_DN=$_PROJECTS_DN
 

--- a/ad-joining/register-computer/gcp/project.py
+++ b/ad-joining/register-computer/gcp/project.py
@@ -25,7 +25,7 @@ import googleapiclient.discovery
 from googleapiclient.errors import HttpError
 import googleapiclient.http
 
-USER_AGENT = "cloud-solutions/gce-automated-ad-join-v1"
+USER_AGENT = "cloud-solutions/gce-automated-ad-join-v2"
 
 class Project(object):
     def __init__(self, project_id):


### PR DESCRIPTION
Extend cleanup logic so that it not only deletes the
computer object, but also the associated DNS record

Note: For DNS cleanup to work, the register-computer
      account must be granted delete-access to the
      respective container in Active Directory.