### PR TITLE
Conditionally skip DNS record cleanup

### DIFF
--- a/ad-joining/register-computer/ad/domain.py
+++ b/ad-joining/register-computer/ad/domain.py
@@ -431,6 +431,10 @@ class Computer(NamedObject):
             DC=host,DC=domain.tld,CN=MicrosoftDNS,DC=DomainDnsZones,DC=domain,DC=tld
         """
 
+        if not self.__dns_hostname:
+            # Some computer objects might not have a DNS hostname
+            return None
+
         dns_hostname_parts = self.__dns_hostname.lower().split('.')
         hostname = dns_hostname_parts[0]
         domain = dns_hostname_parts[1:]

--- a/ad-joining/register-computer/main.py
+++ b/ad-joining/register-computer/main.py
@@ -47,7 +47,7 @@ MAX_NETBIOS_COMPUTER_NAME_LENGTH = 15
 PASSWORD_RESET_RETRIES = 10
 
 PROGRAM_NAME = "ad-joining"
-PROGRAM_VERSION = "2.1.0"
+PROGRAM_VERSION = "2.1.1"
 
 #------------------------------------------------------------------------------
 # Utility functions.

--- a/ad-joining/register-computer/main.py
+++ b/ad-joining/register-computer/main.py
@@ -702,8 +702,11 @@ def __cleanup_computers(request):
  
                     # Delete the DNS record
                     try:
-                        ad_connection.delete_dns_record(computer.get_dns_record_dn())
-                        dns_records_deleted += 1
+                        if computer.get_dns_record_dn():
+                            logging.info("Computer account '%s' has a stale DNS record: %s" 
+                                % (computer.get_name(), computer.get_dns_record_dn()))
+                            ad_connection.delete_dns_record(computer.get_dns_record_dn())
+                            dns_records_deleted += 1
 
                     except ad.domain.NoSuchObjectException as e:
                         pass


### PR DESCRIPTION
Skip DNS record cleanup for computer accounts that
don't have a `dNSHostName`.

Fixes #96