### PR TITLE
Perform recursive delete on stale computer accounts

### DIFF
--- a/ad-joining/register-computer/ad/domain.py
+++ b/ad-joining/register-computer/ad/domain.py
@@ -284,7 +284,10 @@ class ActiveDirectoryConnection(object):
 
     def delete_computer(self, computer_dn):
         try:
-            self.__connection.delete(computer_dn)
+            # Computer accounts can have children. Use LDAP_SERVER_TREE_DELETE_OID
+            # to perform a recursive delete operation (with criticality = True).
+            recursive_delete = ('1.2.840.113556.1.4.805', True, None)
+            self.__connection.delete(computer_dn, controls=[recursive_delete])
         except ldap3.core.exceptions.LDAPNoSuchObjectResult as e:
             raise NoSuchObjectException(e)
 

--- a/ad-joining/register-computer/main.py
+++ b/ad-joining/register-computer/main.py
@@ -47,7 +47,7 @@ MAX_NETBIOS_COMPUTER_NAME_LENGTH = 15
 PASSWORD_RESET_RETRIES = 10
 
 PROGRAM_NAME = "ad-joining"
-PROGRAM_VERSION = "2.1.1"
+PROGRAM_VERSION = "2.1.2"
 
 #------------------------------------------------------------------------------
 # Utility functions.


### PR DESCRIPTION
Computer accounts can have children. Apply the
LDAP_SERVER_TREE_DELETE_OID control when deleting
computer accounts to ensure proper cleanup.

Cf #96